### PR TITLE
feat(auth)!: remove username from signup and update auth branding UI

### DIFF
--- a/backend/prisma/migrations/20260411120000_remove_username/migration.sql
+++ b/backend/prisma/migrations/20260411120000_remove_username/migration.sql
@@ -1,0 +1,3 @@
+-- Remove username from users table
+ALTER TABLE "users"
+DROP COLUMN "username";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,7 +14,6 @@ datasource db {
 
 model User {
   userID        Int      @id @default(autoincrement())
-  username      String   @unique @db.VarChar(100)
   name          String   @db.VarChar(100)
   surname       String   @db.VarChar(100)
   email         String   @unique @db.VarChar(255)

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -34,15 +34,8 @@ async function findOrCreateGoogleUser({ email, given_name, family_name, sub: goo
     let user = await prisma.user.findUnique({ where: { email } });
 
     if (!user) {
-        let username = email.split('@')[0].replace(/[^a-zA-Z0-9_]/g, '_');
-        const usernameExists = await prisma.user.findUnique({ where: { username } });
-        if (usernameExists) {
-            username = `${username}_${googleSub.slice(-4)}`;
-        }
-
         user = await prisma.user.create({
             data: {
-                username,
                 name: given_name || 'Google',
                 surname: family_name || 'User',
                 email,
@@ -59,7 +52,6 @@ async function findOrCreateGoogleUser({ email, given_name, family_name, sub: goo
 router.post(
     '/register',
     [
-        body('username').trim().notEmpty().withMessage('Username is required'),
         body('name').trim().notEmpty().withMessage('Name is required'),
         body('surname').trim().notEmpty().withMessage('Surname is required'),
         body('email').isEmail().normalizeEmail().withMessage('Valid email is required'),
@@ -73,22 +65,19 @@ router.post(
             return res.status(400).json({ errors: errors.array() });
         }
 
-        const { username, name, surname, email, password } = req.body;
+        const { name, surname, email, password } = req.body;
 
         try {
-            const existing = await prisma.user.findFirst({
-                where: { OR: [{ email }, { username }] },
-            });
+            const existing = await prisma.user.findUnique({ where: { email } });
 
             if (existing) {
-                const field = existing.email === email ? 'email' : 'username';
-                return res.status(409).json({ message: `That ${field} is already in use` });
+                return res.status(409).json({ message: 'That email is already in use' });
             }
 
             const password_hash = await bcrypt.hash(password, 12);
 
             const user = await prisma.user.create({
-                data: { username, name, surname, email, password_hash },
+                data: { name, surname, email, password_hash },
             });
 
             issueTokenCookie(res, { userID: user.userID, email: user.email, role: user.role });

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -17,10 +17,10 @@ async function request(path, options = {}) {
 }
 
 export const authApi = {
-    register: (username, name, surname, email, password) =>
+    register: (name, surname, email, password) =>
         request('/api/auth/register', {
             method: 'POST',
-            body: JSON.stringify({ username, name, surname, email, password }),
+            body: JSON.stringify({ name, surname, email, password }),
         }),
 
     login: (email, password) =>

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -22,8 +22,8 @@ export function AuthProvider({ children }) {
         return data.user;
     }
 
-    async function register(username, name, surname, email, password) {
-        const data = await authApi.register(username, name, surname, email, password);
+    async function register(name, surname, email, password) {
+        const data = await authApi.register(name, surname, email, password);
         setUser(data.user);
         return data.user;
     }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -14,7 +14,6 @@ import {
 import { useForm } from '@mantine/form';
 import { useGoogleLogin } from '@react-oauth/google';
 import { useAuth } from '../context/AuthContext.jsx';
-import logo from '../assets/hero.png';
 import './auth.scss';
 
 function GoogleIcon() {
@@ -77,9 +76,9 @@ export default function Login() {
     return (
         <div className="auth-page">
             <div className="auth-card">
-                {/* Mini logo */}
-                <div className="auth-logo">
-                    <img src={logo} alt="MicroTrack" />
+                <div className="auth-brand">
+                    <img src="/favicon.svg" alt="MicroTrack" />
+                    <Text size="lg"><strong>Mirco</strong>Track</Text>
                 </div>
 
                 <Title order={2} className="auth-title">

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -78,7 +78,7 @@ export default function Login() {
             <div className="auth-card">
                 <div className="auth-brand">
                     <img src="/favicon.svg" alt="MicroTrack" />
-                    <Text size="lg"><strong>Mirco</strong>Track</Text>
+                    <Text size="lg"><strong>Micro</strong>Track</Text>
                 </div>
 
                 <Title order={2} className="auth-title">

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -95,7 +95,7 @@ export default function SignUp() {
             <div className="auth-card">
                 <div className="auth-brand">
                     <img src="/favicon.svg" alt="MicroTrack" />
-                    <Text size="lg"><strong>Mirco</strong>Track</Text>
+                    <Text size="lg"><strong>Micro</strong>Track</Text>
                 </div>
 
                 <form onSubmit={form.onSubmit(handleSubmit)} style={{ width: '100%' }}>

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -14,7 +14,6 @@ import {
 import { useForm } from '@mantine/form';
 import { useGoogleLogin } from '@react-oauth/google';
 import { useAuth } from '../context/AuthContext.jsx';
-import logo from '../assets/hero.png';
 import './auth.scss';
 
 function GoogleIcon() {
@@ -37,7 +36,6 @@ export default function SignUp() {
 
     const form = useForm({
         initialValues: {
-            username: '',
             name: '',
             surname: '',
             email: '',
@@ -46,8 +44,6 @@ export default function SignUp() {
             rememberMe: false,
         },
         validate: {
-            username: (v) =>
-                v.trim().length > 0 ? null : 'Username is required',
             name: (v) => (v.trim().length > 0 ? null : 'Name is required'),
             surname: (v) => (v.trim().length > 0 ? null : 'Surname is required'),
             email: (v) => (/^\S+@\S+$/.test(v) ? null : 'Please enter a valid email'),
@@ -63,7 +59,6 @@ export default function SignUp() {
         setError('');
         try {
             await register(
-                values.username,
                 values.name,
                 values.surname,
                 values.email,
@@ -98,20 +93,13 @@ export default function SignUp() {
     return (
         <div className="auth-page">
             <div className="auth-card">
-                {/* Mini logo */}
-                <div className="auth-logo">
-                    <img src={logo} alt="MicroTrack" />
+                <div className="auth-brand">
+                    <img src="/favicon.svg" alt="MicroTrack" />
+                    <Text size="lg"><strong>Mirco</strong>Track</Text>
                 </div>
 
                 <form onSubmit={form.onSubmit(handleSubmit)} style={{ width: '100%' }}>
                     <Stack gap="sm">
-                        <TextInput
-                            label="Username"
-                            placeholder="Create a username"
-                            classNames={{ input: 'auth-input' }}
-                            {...form.getInputProps('username')}
-                        />
-
                         <Title order={2} className="auth-title">
                             Sign up
                         </Title>

--- a/frontend/src/pages/auth.scss
+++ b/frontend/src/pages/auth.scss
@@ -15,18 +15,27 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.75rem;
+    border: 1px solid #B0BEC5;
+    border-radius: 10px;
+    padding: 1.25rem;
+    background: #fff;
 
     form {
         width: 100%;
     }
 }
 
-.auth-logo {
-    margin-bottom: 0.75rem;
+.auth-brand {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
 
     img {
-        height: 48px;
+        height: 36px;
         object-fit: contain;
     }
 }


### PR DESCRIPTION
Remove username from the authentication flow and database model. Update backend register and Google user creation logic to use name, surname, email, and password only. Update frontend signup form and auth API/context to remove username input and payload handling. Replace auth page hero image with favicon branding plus MircoTrack text on login and signup. Add a light grey bordered auth card container with internal spacing for clearer layout.

BREAKING CHANGE: registration payload no longer accepts username, and the users table no longer includes a username column.