### PR TITLE
Add manual SIR override and revert-to-AI functionality

### DIFF
--- a/backend/prisma/migrations/20260607150000_add_predicted_phenotype_manual_override/migration.sql
+++ b/backend/prisma/migrations/20260607150000_add_predicted_phenotype_manual_override/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "predicted_phenotypes"
+ADD COLUMN "ai_resistant" BOOLEAN,
+ADD COLUMN "is_manual_override" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE "predicted_phenotypes"
+SET "ai_resistant" = "resistant"
+WHERE "ai_resistant" IS NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -88,6 +88,8 @@ model PredictedPhenotype {
   organism     String? @db.VarChar(255)
   antibiotic   String? @db.VarChar(255)
   resistant    Boolean?
+  ai_resistant Boolean?
+  is_manual_override Boolean @default(false)
 
   sample Sample @relation(fields: [sample_id], references: [sample_id])
 

--- a/backend/routes/predicted-phenotypes.routes.js
+++ b/backend/routes/predicted-phenotypes.routes.js
@@ -18,6 +18,8 @@ router.post(
         body('organism').optional().trim().isString(),
         body('antibiotic').optional().trim().isString(),
         body('resistant').optional().isBoolean(),
+        body('ai_resistant').optional({nullable: true}).isBoolean(),
+        body('is_manual_override').optional().isBoolean(),
     ],
     async (req, res) => {
         const errors = validationResult(req)
@@ -25,7 +27,7 @@ router.post(
             return res.status(400).json({errors: errors.array()})
         }
 
-        const {sample_id, organism, antibiotic, resistant} = req.body
+        const {sample_id, organism, antibiotic, resistant, ai_resistant, is_manual_override} = req.body
 
         try {
             const sample = await prisma.sample.findUnique({where: {sample_id}})
@@ -39,6 +41,13 @@ router.post(
                     organism,
                     antibiotic,
                     resistant: resistant !== undefined ? Boolean(resistant) : null,
+                    ai_resistant:
+                        ai_resistant !== undefined && ai_resistant !== null
+                            ? Boolean(ai_resistant)
+                            : resistant !== undefined
+                              ? Boolean(resistant)
+                              : null,
+                    is_manual_override: is_manual_override !== undefined ? Boolean(is_manual_override) : false,
                 },
             })
             return res.status(201).json({phenotype})
@@ -132,6 +141,7 @@ router.put(
         body('organism').optional().trim().isString(),
         body('antibiotic').optional().trim().isString(),
         body('resistant').optional().isBoolean(),
+        body('clear_manual_override').optional().isBoolean(),
     ],
     async (req, res) => {
         const errors = validationResult(req)
@@ -140,14 +150,46 @@ router.put(
         }
 
         const {phenotype_id} = req.params
+        const phenotypeId = parseInt(phenotype_id)
+        const existing = await prisma.predictedPhenotype.findUnique({
+            where: {phenotype_id: phenotypeId},
+        })
+
+        if (!existing) {
+            return res.status(404).json({message: 'Predicted phenotype not found'})
+        }
+
         const updateData = {}
         if (req.body.organism !== undefined) updateData.organism = req.body.organism
         if (req.body.antibiotic !== undefined) updateData.antibiotic = req.body.antibiotic
-        if (req.body.resistant !== undefined) updateData.resistant = Boolean(req.body.resistant)
+        if (req.body.resistant !== undefined) {
+            const nextResistant = Boolean(req.body.resistant)
+            const aiResistant =
+                existing.ai_resistant === null || existing.ai_resistant === undefined
+                    ? existing.resistant
+                    : existing.ai_resistant
+
+            updateData.resistant = nextResistant
+            if (existing.ai_resistant === null || existing.ai_resistant === undefined) {
+                updateData.ai_resistant = existing.resistant
+            }
+            updateData.is_manual_override =
+                aiResistant === null || aiResistant === undefined ? true : nextResistant !== aiResistant
+        }
+
+        if (req.body.clear_manual_override === true) {
+            if (existing.ai_resistant === null || existing.ai_resistant === undefined) {
+                updateData.ai_resistant = existing.resistant
+                updateData.resistant = existing.resistant
+            } else {
+                updateData.resistant = existing.ai_resistant
+            }
+            updateData.is_manual_override = false
+        }
 
         try {
             const phenotype = await prisma.predictedPhenotype.update({
-                where: {phenotype_id: parseInt(phenotype_id)},
+                where: {phenotype_id: phenotypeId},
                 data: updateData,
             })
             return res.json({phenotype})

--- a/backend/tests/predicted-phenotypes.routes.test.js
+++ b/backend/tests/predicted-phenotypes.routes.test.js
@@ -145,6 +145,11 @@ describe('PUT /api/predicted-phenotypes/:phenotype_id', () => {
     })
 
     test('updates resistant (last field) successfully', async () => {
+        mockPrismaPhenotype.findUnique.mockResolvedValue({
+            ...phenotypeFixture,
+            ai_resistant: true,
+            is_manual_override: false,
+        })
         const updated = {...phenotypeFixture, resistant: false}
         mockPrismaPhenotype.update.mockResolvedValue(updated)
 
@@ -157,11 +162,45 @@ describe('PUT /api/predicted-phenotypes/:phenotype_id', () => {
         expect(res.body.phenotype.resistant).toBe(false)
         expect(mockPrismaPhenotype.update).toHaveBeenCalledWith({
             where: {phenotype_id: 1},
-            data: {resistant: false},
+            data: {
+                resistant: false,
+                is_manual_override: true,
+            },
+        })
+    })
+
+    test('clears manual override and backfills null ai_resistant', async () => {
+        mockPrismaPhenotype.findUnique.mockResolvedValue({
+            ...phenotypeFixture,
+            resistant: true,
+            ai_resistant: null,
+            is_manual_override: true,
+        })
+        mockPrismaPhenotype.update.mockResolvedValue({
+            ...phenotypeFixture,
+            resistant: true,
+            ai_resistant: true,
+            is_manual_override: false,
+        })
+
+        const res = await api()
+            .put('/api/predicted-phenotypes/1')
+            .set('Cookie', authCookie())
+            .send({clear_manual_override: true})
+
+        expect(res.status).toBe(200)
+        expect(mockPrismaPhenotype.update).toHaveBeenCalledWith({
+            where: {phenotype_id: 1},
+            data: {
+                ai_resistant: true,
+                resistant: true,
+                is_manual_override: false,
+            },
         })
     })
 
     test('returns 404 if not found', async () => {
+        mockPrismaPhenotype.findUnique.mockResolvedValue(phenotypeFixture)
         const error = new Error('not found')
         error.code = 'P2025'
         mockPrismaPhenotype.update.mockRejectedValue(error)

--- a/frontend/src/components/captured-data-components/edit-phenotype-modal.jsx
+++ b/frontend/src/components/captured-data-components/edit-phenotype-modal.jsx
@@ -15,6 +15,7 @@ const EditPhenotypeModal = ({opened, onClose, record, onSave}) => {
         organism: '',
         antibiotic: '',
         resistant: false,
+        manualOverride: false,
     });
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
@@ -51,6 +52,7 @@ const EditPhenotypeModal = ({opened, onClose, record, onSave}) => {
                 organism: record.organism ?? '',
                 antibiotic: record.antibiotic ?? '',
                 resistant: record.resistant ?? false,
+                manualOverride: Boolean(record.is_manual_override),
             });
             setError('');
         }
@@ -71,8 +73,13 @@ const EditPhenotypeModal = ({opened, onClose, record, onSave}) => {
             const updateData = {
                 organism: formData.organism,
                 antibiotic: formData.antibiotic,
-                resistant: formData.resistant,
             };
+
+            if (formData.manualOverride) {
+                updateData.resistant = formData.resistant;
+            } else if (record?.is_manual_override) {
+                updateData.clear_manual_override = true;
+            }
 
             await onSave(record.phenotype_id, updateData);
             onClose();
@@ -127,9 +134,24 @@ const EditPhenotypeModal = ({opened, onClose, record, onSave}) => {
                 />
 
                 <Checkbox
-                    label="Resistant"
-                    checked={formData.resistant}
-                    onChange={(e) => setFormData({...formData, resistant: e.currentTarget.checked})}
+                    label="Use manual override"
+                    checked={formData.manualOverride}
+                    onChange={(e) => setFormData({...formData, manualOverride: e.currentTarget.checked})}
+                />
+
+                <Text size="sm" c="dimmed">
+                    AI prediction: {record?.ai_resistant === true ? 'Resistant' : record?.ai_resistant === false ? 'Susceptible' : 'Unknown'}
+                </Text>
+
+                <Select
+                    label="Resistance Status"
+                    data={[
+                        {value: 'susceptible', label: 'Susceptible'},
+                        {value: 'resistant', label: 'Resistant'},
+                    ]}
+                    value={formData.resistant ? 'resistant' : 'susceptible'}
+                    onChange={(value) => setFormData({...formData, resistant: value === 'resistant'})}
+                    disabled={!formData.manualOverride}
                 />
 
                 <Group justify="space-between" mt="lg">

--- a/frontend/src/components/captured-data-components/predicted-phenotypes-table.jsx
+++ b/frontend/src/components/captured-data-components/predicted-phenotypes-table.jsx
@@ -50,6 +50,17 @@ const PredictedPhenotypesTable = ({records, highlightedSampleIds, onExpandClick,
                     ),
                 },
                 {
+                    accessor: 'is_manual_override',
+                    title: 'Source',
+                    width: 120,
+                    textAlignment: 'center',
+                    render: (record) => (
+                        <Badge color={record.is_manual_override ? 'orange' : 'gray'} variant='outline'>
+                            {record.is_manual_override ? 'Manual' : 'AI'}
+                        </Badge>
+                    ),
+                },
+                {
                     accessor: 'actions',
                     title: '',
                     width: 80,


### PR DESCRIPTION
## Summary
Implemented manual overwrite support for AI-generated SIR prediction in Predicted Phenotypes.

### What changed

1. Added backend support for manual override state and AI baseline tracking.
2. Added clear manual override behavior that restores AI-derived value and source.
3. Added handling for legacy rows where ai_resistant is null during clear override.
4. Updated UI edit modal:
5. Manual override control remains.
6. Resistance input is now a dropdown with Susceptible/Resistant.
7. Updated phenotypes table label from Final Resistance to Resistance Status.
8. Added/updated route tests for manual override behavior and null-ai_resistant fallback.

## Validation performed

1. Backend Jest: 8 suites passed, 169 tests passed.
2. Targeted predicted phenotypes route tests: passing (including clear-manual-override null-ai_resistant case).
3. Frontend Vitest: passing.
4. Frontend production build: passing (exit code 0).
5. Browser flow verified:
6. Enable manual override and save -> Source shows Manual.
7. Disable manual override and save -> value reverts to AI and Source shows AI.

## Notes
Repo-wide frontend lint currently reports pre-existing unrelated issues across multiple files not introduced by this feature. This PR is scoped to the manual SIR override feature only.