### PR TITLE
Fix deployed auth 404 caused by malformed API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ This will list all running containers. To see all containers (including stopped 
 ```
 docker ps -a
 ```
+
+## Deployment Notes (Auth + API)
+
+When deploying frontend and backend separately (for example frontend on Vercel and backend on Render), set these environment variables carefully:
+
+- Frontend: `VITE_API_URL=https://your-backend-domain.com` (no trailing slash)
+- Backend: `FRONTEND_URL=https://your-frontend-domain.com` (can be a comma-separated list for multiple frontends)
+- Backend: set `NODE_ENV=production`
+
+If `VITE_API_URL` includes a trailing slash (for example `https://api.example.com/`), some requests can become malformed and return 404s. The frontend now normalizes this, but using a slash-free value is still recommended.

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,10 +24,41 @@ dotenv.config({path: '../.env'})
 const app = express()
 const port = process.env.PORT || 3000
 
+function normalizeOrigin(origin) {
+    return String(origin || '').replace(/\/+$/, '')
+}
+
+function parseAllowedOrigins(rawOrigins) {
+    return String(rawOrigins || '')
+        .split(',')
+        .map((origin) => normalizeOrigin(origin.trim()))
+        .filter(Boolean)
+}
+
 // Middleware
+const configuredOrigins = parseAllowedOrigins(process.env.FRONTEND_URL)
+
 const corsOptions =
     process.env.NODE_ENV === 'production'
-        ? {origin: process.env.FRONTEND_URL, credentials: true}
+        ? {
+              origin(origin, callback) {
+                  // Allow non-browser clients (no Origin header).
+                  if (!origin) {
+                      callback(null, true)
+                      return
+                  }
+
+                  if (configuredOrigins.length === 0) {
+                      callback(null, true)
+                      return
+                  }
+
+                  const normalizedOrigin = normalizeOrigin(origin)
+                  const isAllowed = configuredOrigins.includes(normalizedOrigin)
+                  callback(null, isAllowed)
+              },
+              credentials: true,
+          }
         : {origin: true, credentials: true} // Allow all origins in development
 
 app.use(cors(corsOptions))

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,4 +1,4 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+import { buildApiUrl } from './api-client.js'
 
 const fallbackMessageByStatus = {
     400: 'Invalid admin request',
@@ -20,7 +20,7 @@ function buildRequestError(path, response, data) {
 }
 
 async function request(path, options = {}) {
-    const res = await fetch(`${API_URL}${path}`, {
+    const res = await fetch(buildApiUrl(path), {
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         ...options,

--- a/frontend/src/api/api-client.js
+++ b/frontend/src/api/api-client.js
@@ -1,0 +1,24 @@
+const DEFAULT_DEV_API_URL = 'http://localhost:3000';
+
+function stripTrailingSlashes(value) {
+    return String(value || '').replace(/\/+$/, '');
+}
+
+export function getApiBaseUrl() {
+    const envUrl = stripTrailingSlashes(import.meta.env.VITE_API_URL);
+    if (envUrl) {
+        return envUrl;
+    }
+
+    if (import.meta.env.DEV) {
+        return DEFAULT_DEV_API_URL;
+    }
+
+    return '';
+}
+
+export function buildApiUrl(path) {
+    const baseUrl = getApiBaseUrl();
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    return `${baseUrl}${normalizedPath}`;
+}

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,4 +1,4 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+import { buildApiUrl } from './api-client.js';
 
 const fallbackMessageByStatus = {
     400: 'Invalid request',
@@ -27,7 +27,7 @@ async function request(path, options = {}) {
         headers['Content-Type'] = 'application/json';
     }
 
-    const res = await fetch(`${API_URL}${path}`, {
+    const res = await fetch(buildApiUrl(path), {
         credentials: 'include', // send/receive the httpOnly cookie
         ...rest,
         headers,

--- a/frontend/src/api/sample-data-management.js
+++ b/frontend/src/api/sample-data-management.js
@@ -1,8 +1,8 @@
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+import { buildApiUrl } from './api-client.js'
 
 async function request(path, options = {}) {
     const {signal, ...restOptions} = options
-    const res = await fetch(`${API_URL}${path}`, {
+    const res = await fetch(buildApiUrl(path), {
         headers: {'Content-Type': 'application/json'},
         credentials: 'include',
         signal,
@@ -28,7 +28,7 @@ export const extractSampleFromImage = async (file) => {
     const formData = new FormData()
     formData.append('image', file)
 
-    const res = await fetch(`${API_URL}/api/samples/extract-image`, {
+    const res = await fetch(buildApiUrl('/api/samples/extract-image'), {
         method: 'POST',
         credentials: 'include',
         body: formData,
@@ -50,7 +50,7 @@ export const extractSamplesFromImage = async (file) => {
     formData.append('image', file)
     formData.append('mode', 'multi')
 
-    const res = await fetch(`${API_URL}/api/samples/extract-image`, {
+    const res = await fetch(buildApiUrl('/api/samples/extract-image'), {
         method: 'POST',
         credentials: 'include',
         body: formData,

--- a/frontend/src/components/captured-data-components/bulk-upload-modal.jsx
+++ b/frontend/src/components/captured-data-components/bulk-upload-modal.jsx
@@ -17,8 +17,7 @@ import {
 } from '@mantine/core';
 import {AlertCircle, CheckCircle, FileUp, Image as ImageIcon, X} from 'lucide-react';
 import styles from './bulk-upload-modal.module.scss';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+import {buildApiUrl} from '../../api/api-client.js';
 
 // Normalise the backend's upload response into the summary shape the results
 // panel renders. The /api/bulk-upload/samples endpoint returns `results` as a
@@ -328,7 +327,7 @@ export default function BulkUploadModal({isOpen, onClose, onUploadSuccess}) {
             const formData = new FormData();
             formData.append('file', fileToUpload);
 
-            const endpoint = specificEndpoint ? `${API_URL}${specificEndpoint}` : `${API_URL}/api/bulk-upload/samples`;
+            const endpoint = buildApiUrl(specificEndpoint || '/api/bulk-upload/samples');
             const response = await fetch(endpoint, {
                 method: 'POST',
                 body: formData,

--- a/frontend/src/components/dashboard/dashboard-navbar.jsx
+++ b/frontend/src/components/dashboard/dashboard-navbar.jsx
@@ -40,13 +40,6 @@ export default function DashboardNavbar() {
     const isAuthenticated = Boolean(user);
     const isAdmin = user?.role === 'admin';
 
-    // Debug logging
-    useEffect(() => {
-        console.log('User:', user);
-        console.log('isAuthenticated:', isAuthenticated);
-        console.log('isAdmin:', isAdmin);
-        console.log('user?.role:', user?.role);
-    }, [user, isAuthenticated, isAdmin]);
     const avatarSrc = user?.profileImage || null;
     const avatarName = `${user?.name || ''} ${user?.surname || ''}`.trim();
 

--- a/frontend/src/hooks/useAiFilter.js
+++ b/frontend/src/hooks/useAiFilter.js
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+import { buildApiUrl } from '../api/api-client.js'
 
 function applyFiltersToSamples(samples, filters) {
     if (!filters || filters.length === 0) return samples
@@ -45,7 +44,7 @@ export function useAiFilter() {
         setLoading(true)
         setError(null)
         try {
-            const res = await fetch(`${API_URL}/api/ai/filter`, {
+            const res = await fetch(buildApiUrl('/api/ai/filter'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',


### PR DESCRIPTION
Add a shared api-client to normalize VITE_API_URL and build request URLs (strip trailing slashes, handle dev fallback) and update frontend modules (admin, auth, sample-data-management, bulk upload, useAiFilter) to use buildApiUrl. Enhance backend/server.js to parse FRONTEND_URL as a comma-separated list, normalize origins, and enforce allowed origins in production while permitting non-browser clients. Add deployment notes to README about VITE_API_URL/FRONTEND_URL and trailing-slash pitfalls. Also remove debug logging from the dashboard navbar.