### PR TITLE
Centralize token cookie options and Forgot your password removed

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -67,15 +67,23 @@ const profileImageUpload = multer({
 
 // ─── Cookie helper ───────────────────────────────────────────────────────────
 
+function getTokenCookieOptions() {
+    const isProduction = process.env.NODE_ENV === 'production'
+
+    return {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: isProduction ? 'none' : 'lax',
+    }
+}
+
 function issueTokenCookie(res, payload) {
     const token = jwt.sign(payload, jwtSecret, {
         expiresIn: process.env.JWT_EXPIRES_IN || '7d',
     })
 
     res.cookie('token', token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
+        ...getTokenCookieOptions(),
         maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
     })
 
@@ -360,7 +368,7 @@ router.post(
 // ─── POST /api/auth/logout ───────────────────────────────────────────────────
 
 router.post('/logout', (req, res) => {
-    res.clearCookie('token', { httpOnly: true, sameSite: 'lax' })
+    res.clearCookie('token', getTokenCookieOptions())
     return res.json({ message: 'Logged out' })
 })
 

--- a/backend/tests/auth.routes.test.js
+++ b/backend/tests/auth.routes.test.js
@@ -97,6 +97,10 @@ afterAll(() => {
     delete global.fetch
 })
 
+afterEach(() => {
+    process.env.NODE_ENV = 'test'
+})
+
 describe('POST /api/auth/register', () => {
     test('returns 400 when required fields are missing', async () => {
         const res = await api().post('/api/auth/register').send({})
@@ -141,6 +145,23 @@ describe('POST /api/auth/register', () => {
         expect(res.status).toBe(201)
         expect(res.body.user.email).toBe('newuser@example.com')
         expect(res.headers['set-cookie']).toBeDefined()
+    })
+
+    test('uses cross-site cookie attributes in production registration responses', async () => {
+        process.env.NODE_ENV = 'production'
+        mockPrismaUser.findUnique.mockResolvedValue(null)
+        mockPrismaUser.create.mockResolvedValue(makeUser({ email: 'produser@example.com' }))
+
+        const res = await api().post('/api/auth/register').send({
+            name: 'Prod',
+            surname: 'User',
+            email: 'produser@example.com',
+            password: 'securepass123',
+        })
+
+        expect(res.status).toBe(201)
+        expect(res.headers['set-cookie'][0]).toContain('SameSite=None')
+        expect(res.headers['set-cookie'][0]).toContain('Secure')
     })
 
     test('returns 500 when registration fails unexpectedly', async () => {
@@ -229,6 +250,16 @@ describe('POST /api/auth/logout', () => {
         const res = await api().post('/api/auth/logout')
         expect(res.status).toBe(200)
         expect(res.body.message).toMatch(/logged out/i)
+    })
+
+    test('uses matching cross-site cookie attributes in production logout responses', async () => {
+        process.env.NODE_ENV = 'production'
+
+        const res = await api().post('/api/auth/logout')
+
+        expect(res.status).toBe(200)
+        expect(res.headers['set-cookie'][0]).toContain('SameSite=None')
+        expect(res.headers['set-cookie'][0]).toContain('Secure')
     })
 })
 

--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -196,12 +196,6 @@ export default function Login() {
                             Sign In
                         </Button>
 
-                        <div className='auth-forgot'>
-                            <Anchor size='xs' href='/forgot-password'>
-                                Forgot your password?
-                            </Anchor>
-                        </div>
-
                         {isGoogleAuthEnabled && (
                             <>
                                 <Divider label='or' labelPosition='center' />

--- a/frontend/src/pages/sign-up.jsx
+++ b/frontend/src/pages/sign-up.jsx
@@ -209,12 +209,6 @@ export default function SignUp() {
                             Sign Up
                         </Button>
 
-                        <div className='auth-forgot'>
-                            <Anchor size='xs' href='/forgot-password'>
-                                Forgot your password?
-                            </Anchor>
-                        </div>
-
                         {isGoogleAuthEnabled && (
                             <>
                                 <Divider label='or' labelPosition='center' />


### PR DESCRIPTION
Introduce getTokenCookieOptions to centralize cookie attributes for the auth token (httpOnly, secure enabled in production, SameSite=None in production otherwise lax) and use it when issuing and clearing the token cookie. Update tests to reset NODE_ENV to 'test' after each run and add assertions that registration and logout responses include SameSite=None and Secure when NODE_ENV='production'. Remove the 'Forgot your password?' links from the login and sign-up pages as a UI cleanup.