### PR TITLE
Adjust auth cookie policy and disable auth caching

### DIFF
--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -68,12 +68,15 @@ const profileImageUpload = multer({
 // ─── Cookie helper ───────────────────────────────────────────────────────────
 
 function getTokenCookieOptions() {
-    const isProduction = process.env.NODE_ENV === 'production'
+    const frontendUrl = String(process.env.FRONTEND_URL || '').trim().toLowerCase()
+    const isHttpsFrontend = frontendUrl.startsWith('https://')
+    const isLocalFrontend = frontendUrl.includes('localhost') || frontendUrl.includes('127.0.0.1')
+    const useCrossSiteCookie = process.env.NODE_ENV === 'production' || (isHttpsFrontend && !isLocalFrontend)
 
     return {
         httpOnly: true,
-        secure: isProduction,
-        sameSite: isProduction ? 'none' : 'lax',
+        secure: useCrossSiteCookie,
+        sameSite: useCrossSiteCookie ? 'none' : 'lax',
     }
 }
 
@@ -375,6 +378,9 @@ router.post('/logout', (req, res) => {
 // ─── GET /api/auth/me ────────────────────────────────────────────────────────
 
 router.get('/me', async (req, res) => {
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+    res.set('Pragma', 'no-cache')
+
     const token = req.cookies?.token
 
     if (!token) {

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -29,6 +29,7 @@ async function request(path, options = {}) {
 
     const res = await fetch(buildApiUrl(path), {
         credentials: 'include', // send/receive the httpOnly cookie
+        cache: 'no-store',
         ...rest,
         headers,
         body,


### PR DESCRIPTION
Compute frontend URL and derive a useCrossSiteCookie flag so cookies are marked secure and SameSite='none' for production or HTTPS frontends that are not local. Add Cache-Control and Pragma headers on GET /api/auth/me and set fetch cache:'no-store' in the frontend auth request to avoid serving stale cached auth responses. These changes ensure cross-site cookie behavior is correct for secure deployments and prevent caching of sensitive auth data.