### PR TITLE
feat: Tesseract OCR (revert from blocked Textract) + S3-triggered image-processing Lambda

### DIFF
--- a/backend/lib/image-extraction.js
+++ b/backend/lib/image-extraction.js
@@ -1,114 +1,82 @@
+import { existsSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 import sharp from 'sharp'
-import {
-    TextractClient,
-    DetectDocumentTextCommand,
-} from '@aws-sdk/client-textract'
+import { createWorker } from 'tesseract.js'
 import { extractAllFromWords, extractSampleRows } from './sample-field-parser.js'
 
 // ─── Configuration ────────────────────────────────────────────────────────────
 //
-// OCR is performed by Amazon Textract (serverless, managed). Credentials are
-// resolved by the AWS SDK's default provider chain — in production the EC2
-// instance role (microtrack-ec2-role, AmazonTextractFullAccess) supplies them
-// automatically, so no keys live in code. The image buffer is sent to Textract
-// in-memory and never persisted, preserving the original privacy guarantee.
+// Tesseract.js downloads the (free, Apache-2.0) English language model on first
+// use and caches it locally, so subsequent runs are fully offline. Point
+// OCR_LANG_PATH at a directory containing a vendored `eng.traineddata(.gz)` to
+// guarantee offline operation from the very first request.
 
-const REGION = process.env.AWS_REGION || 'us-east-1'
-
-let textractClient = null
-
-function getTextractClient() {
-    if (!textractClient) {
-        textractClient = new TextractClient({ region: REGION })
-    }
-    return textractClient
-}
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CACHE_DIR = path.resolve(__dirname, '../.tesseract-cache')
+const LANG_PATH = process.env.OCR_LANG_PATH || null
 
 // ─── Image pre-processing (Sharp) ────────────────────────────────────────────
 //
-// Fix EXIF orientation and upscale small images. We also need the pixel
-// dimensions of the buffer we send to Textract so we can de-normalise its
-// bounding boxes (Textract returns coordinates as fractions of the page).
+// Mirrors the Sharp usage in routes/auth.routes.js (processProfileImageUpload).
+// Greyscale + contrast normalisation + light sharpening, upscaling small images,
+// markedly improves OCR accuracy. Output is lossless PNG fed to Tesseract.
 
 async function preprocessImage(buffer) {
     const image = sharp(buffer, { failOn: 'error' }).rotate()
     const metadata = await image.metadata()
 
-    let pipeline = image
+    let pipeline = image.greyscale().normalise()
+
     const targetWidth = 1600
     if (metadata.width && metadata.width < targetWidth) {
         pipeline = pipeline.resize({ width: targetWidth })
     }
 
-    const processed = await pipeline.png().toBuffer()
-    const processedMeta = await sharp(processed).metadata()
-    return {
-        buffer: processed,
-        width: processedMeta.width || metadata.width || 1,
-        height: processedMeta.height || metadata.height || 1,
-    }
+    return pipeline.sharpen().png().toBuffer()
 }
 
-// ─── Textract → parser word mapping ──────────────────────────────────────────
-//
-// The geometry-based parser (sample-field-parser.js) expects words shaped as
-// { text, confidence, bbox: {x0,y0,x1,y1} } in pixel coordinates. Textract WORD
-// blocks carry a normalised BoundingBox {Left,Top,Width,Height} (0..1) and a
-// 0..100 Confidence — the same confidence scale Tesseract used. We scale the
-// normalised box back to pixels so the parser's cross-axis heuristics (x-gap vs
-// word height) stay valid for non-square images.
+// ─── Tesseract worker (lazy singleton) ───────────────────────────────────────
 
-function textractWordsToParserWords(blocks, width, height) {
-    return (blocks || [])
-        .filter((b) => b.BlockType === 'WORD' && b.Geometry?.BoundingBox)
-        .map((b) => {
-            const bb = b.Geometry.BoundingBox
-            const x0 = bb.Left * width
-            const y0 = bb.Top * height
-            return {
-                text: b.Text || '',
-                confidence: b.Confidence ?? 0,
-                bbox: {
-                    x0,
-                    y0,
-                    x1: x0 + bb.Width * width,
-                    y1: y0 + bb.Height * height,
-                },
+let workerPromise = null
+
+function getWorker() {
+    if (!workerPromise) {
+        const options = { cachePath: CACHE_DIR, gzip: true, logger: () => {} }
+        if (LANG_PATH && existsSync(LANG_PATH)) options.langPath = LANG_PATH
+        workerPromise = createWorker('eng', 1, options)
+    }
+    return workerPromise
+}
+
+/** Flattens Tesseract's block/paragraph/line hierarchy into a flat word list. */
+function collectWords(data) {
+    if (Array.isArray(data.words) && data.words.length) return data.words
+    const words = []
+    for (const block of data.blocks || []) {
+        for (const para of block.paragraphs || []) {
+            for (const line of para.lines || []) {
+                for (const word of line.words || []) words.push(word)
             }
-        })
-}
-
-/** Joins Textract LINE blocks into the plain-text dump the callers expose as rawText. */
-function rawTextFromBlocks(blocks) {
-    return (blocks || [])
-        .filter((b) => b.BlockType === 'LINE')
-        .map((b) => b.Text || '')
-        .join('\n')
-}
-
-/** Pre-processes the image, runs Textract OCR, and returns parser words + blocks. */
-async function detectWords(buffer) {
-    const { buffer: processed, width, height } = await preprocessImage(buffer)
-    const { Blocks } = await getTextractClient().send(
-        new DetectDocumentTextCommand({ Document: { Bytes: processed } }),
-    )
-    return {
-        words: textractWordsToParserWords(Blocks, width, height),
-        blocks: Blocks,
+        }
     }
+    return words
 }
 
 /**
- * Full pipeline: OCR the image and extract Sample fields plus analysis-detail
- * records (Metagenomic / WGS) and gene lists. The image buffer is never
- * persisted — only the extracted data is returned.
+ * Full pipeline: pre-process the image, OCR it, and extract Sample fields plus
+ * analysis-detail records (Metagenomic / WGS) and gene lists. The image buffer
+ * is never persisted — only the extracted data is returned.
  * @returns {Promise<{fields: object, confidence: object, metagenomic: object[],
  *   wgs: object[], amrGenes: string[], virulenceGenes: string[], rawText: string}>}
  */
 export async function extractSampleFromImageBuffer(buffer) {
-    const { words, blocks } = await detectWords(buffer)
+    const processed = await preprocessImage(buffer)
+    const worker = await getWorker()
+    const { data } = await worker.recognize(processed, {}, { blocks: true })
+    const words = collectWords(data)
     const extracted = extractAllFromWords(words)
-    return { ...extracted, rawText: rawTextFromBlocks(blocks) }
+    return { ...extracted, rawText: data.text || '' }
 }
 
 /**
@@ -117,12 +85,18 @@ export async function extractSampleFromImageBuffer(buffer) {
  * @returns {Promise<{samples: object[], rawText: string}>}
  */
 export async function extractSamplesFromImageBuffer(buffer) {
-    const { words, blocks } = await detectWords(buffer)
-    return { samples: extractSampleRows(words), rawText: rawTextFromBlocks(blocks) }
+    const processed = await preprocessImage(buffer)
+    const worker = await getWorker()
+    const { data } = await worker.recognize(processed, {}, { blocks: true })
+    const words = collectWords(data)
+    return { samples: extractSampleRows(words), rawText: data.text || '' }
 }
 
-/**
- * No-op retained for API compatibility with the previous Tesseract worker
- * (tests called this for teardown). Textract is stateless — nothing to release.
- */
-export async function terminateWorker() {}
+/** Terminates the shared worker (used in tests for clean teardown). */
+export async function terminateWorker() {
+    if (workerPromise) {
+        const worker = await workerPromise
+        await worker.terminate()
+        workerPromise = null
+    }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,6 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
-        "@aws-sdk/client-textract": "^3.700.0",
         "@aws-sdk/s3-request-presigner": "^3.700.0",
         "@prisma/client": "^6.6.0",
         "bcryptjs": "^3.0.3",
@@ -45,6 +44,7 @@
         "papaparse": "^5.4.1",
         "pg": "^8.20.0",
         "sharp": "^0.34.5",
+        "tesseract.js": "^5.1.1",
         "xlsx": "^0.18.5"
     },
     "devDependencies": {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -104,22 +104,6 @@
     "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
-"@aws-sdk/client-textract@^3.700.0":
-  version "3.1068.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-textract/-/client-textract-3.1068.0.tgz#82c7cdcb408c8619007b7db509ceb54c209f217e"
-  integrity sha512-FeG3KvoveZos7afDgVJL9ZRcRKFWqLKO0GCIRJPn1IRUrHuaKV+ADaiPEFRFkW0Kqiqg2wi853o2plJuByIpbQ==
-  dependencies:
-    "@aws-crypto/sha256-browser" "5.2.0"
-    "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "^3.974.20"
-    "@aws-sdk/credential-provider-node" "^3.972.55"
-    "@aws-sdk/types" "^3.973.12"
-    "@smithy/core" "^3.24.6"
-    "@smithy/fetch-http-handler" "^5.4.6"
-    "@smithy/node-http-handler" "^4.7.6"
-    "@smithy/types" "^4.14.3"
-    tslib "^2.6.2"
-
 "@aws-sdk/core@^3.974.20":
   version "3.974.20"
   resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.20.tgz#fc9727897662e148fad2276995298f56b587c3ab"
@@ -1629,6 +1613,11 @@ bignumber.js@^9.0.0:
   resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz"
   integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
 
+bmp-js@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
+  integrity sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==
+
 body-parser@~1.20.5:
   version "1.20.5"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz"
@@ -2589,6 +2578,11 @@ iconv-lite@~0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+idb-keyval@^6.2.0:
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.5.tgz#fce562b07de93507de5ebf89dac9fd8795a9dcea"
+  integrity sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==
+
 import-local@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz"
@@ -2625,6 +2619,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
+is-electron@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
+  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
@@ -2639,6 +2638,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3329,6 +3333,13 @@ node-fetch-native@^1.6.6:
   resolved "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz"
   integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
 
+node-fetch@^2.6.9:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz"
@@ -3409,6 +3420,11 @@ openai@^6.34.0:
   version "6.42.0"
   resolved "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz"
   integrity sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==
+
+opencollective-postinstall@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -3707,6 +3723,11 @@ readdirp@^4.0.1:
   version "4.1.2"
   resolved "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
+
+regenerator-runtime@^0.13.3:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4057,6 +4078,27 @@ synckit@^0.11.8:
   dependencies:
     "@pkgr/core" "^0.3.6"
 
+tesseract.js-core@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tesseract.js-core/-/tesseract.js-core-5.1.1.tgz#2b6f3ef28dd109bf4efdbc8fff70bd11adac8b85"
+  integrity sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==
+
+tesseract.js@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tesseract.js/-/tesseract.js-5.1.1.tgz#7bfaca1c103ba0ce3ddf5e101f0692802a01f880"
+  integrity sha512-lzVl/Ar3P3zhpUT31NjqeCo1f+D5+YfpZ5J62eo2S14QNVOmHBTtbchHm/YAbOOOzCegFnKf4B3Qih9LuldcYQ==
+  dependencies:
+    bmp-js "^0.1.0"
+    idb-keyval "^6.2.0"
+    is-electron "^2.2.2"
+    is-url "^1.2.4"
+    node-fetch "^2.6.9"
+    opencollective-postinstall "^2.0.3"
+    regenerator-runtime "^0.13.3"
+    tesseract.js-core "^5.1.1"
+    wasm-feature-detect "^1.2.11"
+    zlibjs "^0.3.1"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
@@ -4080,6 +4122,11 @@ toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 tslib@^2.4.0, tslib@^2.6.2:
   version "2.8.1"
@@ -4193,10 +4240,28 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
+wasm-feature-detect@^1.2.11:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz#4e9f55b0a64d801f372fbb0324ed11ad3abd0c78"
+  integrity sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==
+
 web-streams-polyfill@^3.0.3:
   version "3.3.3"
   resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"
@@ -4310,3 +4375,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zlibjs@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/zlibjs/-/zlibjs-0.3.1.tgz#50197edb28a1c42ca659cc8b4e6a9ddd6d444554"
+  integrity sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==

--- a/lambda/image-processor/README.md
+++ b/lambda/image-processor/README.md
@@ -1,0 +1,39 @@
+# MicroTrack Image Processor (AWS Lambda)
+
+Serverless image processing. An S3 `ObjectCreated` event under `profile-images/`
+triggers this function, which generates a 64×64 avatar thumbnail (via `jimp`,
+pure-JS) and writes it to `thumbnails/` in the same bucket.
+
+Demonstrates: AWS Lambda (serverless processing) reacting to real-time S3 events
+to perform image processing. Credentials come from the `microtrack-lambda-role`
+execution role; `@aws-sdk/*` v3 is provided by the Node 20 runtime, so only
+`jimp` is bundled.
+
+## Deploy (us-east-1, profile `microtrack`)
+
+```bash
+cd lambda/image-processor
+npm install --omit=dev
+zip -r function.zip index.js node_modules package.json
+
+ROLE_ARN=$(aws iam get-role --role-name microtrack-lambda-role --query 'Role.Arn' --output text --profile microtrack)
+
+aws lambda create-function --function-name microtrack-image-processor \
+  --runtime nodejs20.x --role "$ROLE_ARN" --handler index.handler \
+  --zip-file fileb://function.zip --timeout 30 --memory-size 512 \
+  --region us-east-1 --profile microtrack
+
+# allow S3 to invoke it
+aws lambda add-permission --function-name microtrack-image-processor \
+  --statement-id s3invoke --action lambda:InvokeFunction \
+  --principal s3.amazonaws.com --source-arn arn:aws:s3:::microtrack-images \
+  --region us-east-1 --profile microtrack
+
+# wire the S3 -> Lambda notification (prefix profile-images/)
+aws s3api put-bucket-notification-configuration --bucket microtrack-images \
+  --notification-configuration file://s3-notification.json \
+  --region us-east-1 --profile microtrack
+```
+
+Update code later with:
+`aws lambda update-function-code --function-name microtrack-image-processor --zip-file fileb://function.zip`

--- a/lambda/image-processor/index.js
+++ b/lambda/image-processor/index.js
@@ -1,0 +1,64 @@
+// MicroTrack — serverless image processing.
+//
+// Triggered by S3 ObjectCreated events under the `profile-images/` prefix.
+// When a user uploads a profile picture, this Lambda generates a small 64x64
+// avatar thumbnail and writes it to `thumbnails/` in the same bucket. This
+// demonstrates AWS serverless (Lambda) processing of real-time S3 events for
+// image processing, with no servers to manage.
+//
+// Credentials come from the Lambda execution role (microtrack-lambda-role).
+// @aws-sdk/* v3 is provided by the Lambda Node 20 runtime; only jimp is bundled.
+
+const {
+    S3Client,
+    GetObjectCommand,
+    PutObjectCommand,
+} = require('@aws-sdk/client-s3')
+const Jimp = require('jimp')
+
+const s3 = new S3Client({})
+const THUMB_SIZE = 64
+const SOURCE_PREFIX = 'profile-images/'
+const THUMB_PREFIX = 'thumbnails/'
+
+async function streamToBuffer(stream) {
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+    return Buffer.concat(chunks)
+}
+
+exports.handler = async (event) => {
+    const results = []
+
+    for (const record of event.Records || []) {
+        const bucket = record.s3.bucket.name
+        const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '))
+
+        // Defensive: only process source images, never our own thumbnails.
+        if (!key.startsWith(SOURCE_PREFIX) || key.startsWith(THUMB_PREFIX)) {
+            continue
+        }
+
+        const obj = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+        const input = await streamToBuffer(obj.Body)
+
+        const image = await Jimp.read(input)
+        image.cover(THUMB_SIZE, THUMB_SIZE)
+        const output = await image.getBufferAsync(Jimp.MIME_PNG)
+
+        const thumbKey = THUMB_PREFIX + key.slice(SOURCE_PREFIX.length)
+        await s3.send(
+            new PutObjectCommand({
+                Bucket: bucket,
+                Key: thumbKey,
+                Body: output,
+                ContentType: 'image/png',
+            }),
+        )
+
+        console.log(`Thumbnail created: s3://${bucket}/${thumbKey} (${output.length} bytes)`)
+        results.push(thumbKey)
+    }
+
+    return { ok: true, thumbnails: results }
+}

--- a/lambda/image-processor/package.json
+++ b/lambda/image-processor/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "microtrack-image-processor",
+    "version": "1.0.0",
+    "description": "S3-triggered Lambda that generates profile-image thumbnails",
+    "main": "index.js",
+    "private": true,
+    "dependencies": {
+        "jimp": "^0.22.12"
+    }
+}


### PR DESCRIPTION
## Why
Amazon Textract is **blocked on this AWS account** (`SubscriptionRequiredException` — restricted/student account; Comprehend is blocked too, but EC2/S3/RDS/Lambda/Rekognition work). So the Textract-based OCR from #131 can't run here.

## Changes
- **OCR reverted to in-backend `tesseract.js`** — restored `lib/image-extraction.js`, re-added `tesseract.js`, removed `@aws-sdk/client-textract`. Reliable and the geometry parser was built for it. S3 profile-image storage (from #131) is unchanged.
- **New `lambda/image-processor/`** — an S3 `ObjectCreated` trigger on `profile-images/` that generates a 64×64 avatar thumbnail (`jimp`, pure-JS) into `thumbnails/`. Provides the required **serverless (Lambda)** processing and demonstrates **event-driven image processing**.

## Tests
- 295 pass; coverage 95.22% (also removed stray `* 2` file-sync artifacts that were polluting coverage).

## Deploy notes
- Backend: pull `dev` on EC2 + restart (Tesseract OCR).
- Lambda: deployed via CLI (see `lambda/image-processor/README.md`) + S3 notification on `microtrack-images`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)