### PR TITLE
fix(frontend): stop SW caching /api/* (false 'server waking up')

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -50,15 +50,10 @@ export default defineConfig({
               expiration: { maxEntries: 10, maxAgeSeconds: 60 * 60 * 24 * 365 },
             },
           },
-          {
-            urlPattern: /\/api\/.*/i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api-cache',
-              expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
-              networkTimeoutSeconds: 10,
-            },
-          },
+          // NOTE: /api/* is intentionally NOT cached by the service worker.
+          // It is live dashboard data; caching it (previously NetworkFirst, 24h)
+          // served stale data and, on any blip, surfaced a false "server is
+          // waking up" state. API requests now always go straight to the network.
         ],
       },
     }),


### PR DESCRIPTION
## Problem
The PWA service worker cached `/api/*` with `NetworkFirst` (24h, `api-cache`). For a live-data dashboard this:
- served stale API data, and
- on any network blip/timeout fell back to cache, and when a stale/old app build was cached it surfaced a persistent false **"Server is waking up"** retry state — even though the backend was healthy (verified 10/10 `/api/samples` → 200).

## Fix
Remove the `/api` runtime-caching rule in `vite.config.js`. API requests now always go straight to the network. Font caching is unchanged; the app shell is still precached (offline-capable).

## Deploy
Frontend rebuilt and deployed to `/var/www/microtrack` on EC2; `registerType: 'autoUpdate'` swaps the new service worker into users' browsers on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)