### PR TITLE
fix(admin): delete virulence_genes when deleting a water sample

### DIFF
--- a/backend/routes/admin.routes.js
+++ b/backend/routes/admin.routes.js
@@ -373,6 +373,7 @@ router.delete('/water/samples/:sample_id', async (req, res) => {
             await tx.isolate.deleteMany({where: {sample_id}})
             await tx.amrFinding.deleteMany({where: {sample_id}})
             await tx.predictedPhenotype.deleteMany({where: {sample_id}})
+            await tx.virulenceGene.deleteMany({where: {sample_id}})
             await tx.sample.delete({where: {sample_id}})
             await tx.adminDeleteAudit.create({
                 data: {

--- a/backend/tests/admin.routes.test.js
+++ b/backend/tests/admin.routes.test.js
@@ -55,6 +55,14 @@ const mockPrisma = {
         updateMany: jest.fn(),
         findFirst: jest.fn(),
     },
+    virulenceGene: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+        deleteMany: jest.fn(),
+        count: jest.fn(),
+        updateMany: jest.fn(),
+        findFirst: jest.fn(),
+    },
     adminDeleteAudit: {
         create: jest.fn(),
         findMany: jest.fn(),
@@ -365,6 +373,20 @@ describe('Admin – Water Samples CRUD', () => {
             .send({reason: 'valid deletion reason'})
         expect(res.status).toBe(200)
         expect(mockPrisma.adminDeleteAudit.create).toHaveBeenCalled()
+    })
+
+    test('DELETE /water/samples/:sample_id – clears all child rows before deleting sample', async () => {
+        const res = await api()
+            .delete('/api/admin/water/samples/SAMPLE-001')
+            .set('Cookie', authCookie())
+            .send({reason: 'valid deletion reason'})
+        expect(res.status).toBe(200)
+        // All four child relations must be cleared, else the FK RESTRICT throws a 500.
+        expect(mockPrisma.isolate.deleteMany).toHaveBeenCalledWith({where: {sample_id: 'SAMPLE-001'}})
+        expect(mockPrisma.amrFinding.deleteMany).toHaveBeenCalledWith({where: {sample_id: 'SAMPLE-001'}})
+        expect(mockPrisma.predictedPhenotype.deleteMany).toHaveBeenCalledWith({where: {sample_id: 'SAMPLE-001'}})
+        expect(mockPrisma.virulenceGene.deleteMany).toHaveBeenCalledWith({where: {sample_id: 'SAMPLE-001'}})
+        expect(mockPrisma.sample.delete).toHaveBeenCalledWith({where: {sample_id: 'SAMPLE-001'}})
     })
 
     test('DELETE /water/samples/:sample_id – 400 missing reason', async () => {


### PR DESCRIPTION
## Problem

Deleting certain water samples from the admin dashboard returned a **500 Internal Server Error** (`DELETE /api/admin/water/samples/:id`). The failure depended on the sample: some deleted fine, others always 500'd — the distinguishing factor was whether the sample had **virulence-gene** data attached.

## Root cause

The `DELETE /water/samples/:sample_id` handler removes a sample's child rows inside a transaction before deleting the sample, but it only cleared **three of the four** child tables:

| Child table | Cleared before? |
|---|---|
| `isolates` | ✅ |
| `amr_findings` | ✅ |
| `predicted_phenotypes` | ✅ |
| `virulence_genes` | ❌ missing |

`virulence_genes_sample_id_fkey` is declared `ON DELETE RESTRICT`, so Postgres refuses to delete a `samples` row while any `virulence_genes` row still references it. Samples that went through virulence-gene analysis hit the constraint → exception → caught → 500. Samples without virulence-gene rows deleted cleanly.

## Fix

- Add `tx.virulenceGene.deleteMany({where: {sample_id}})` to the cascade in `backend/routes/admin.routes.js`, before `tx.sample.delete(...)`.
- Add the `virulenceGene` delegate to the Prisma test mock and a regression test asserting **all four** child relations are cleared before the sample is deleted.

## Testing

`yarn test tests/admin.routes.test.js -t "water/samples"` → 7/7 pass, including the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)